### PR TITLE
Add unit tests for DashaMail Client

### DIFF
--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+namespace DashaMail\Tests;
+
+use DashaMail\Client;
+use DashaMail\Exception;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../src/Client.php';
+require_once __DIR__ . '/../src/Exception.php';
+require_once __DIR__ . '/curl_stub.php';
+
+final class ClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        \DashaMail\CurlStub::reset();
+    }
+
+    public function testSuccessfulCallReturnsData(): void
+    {
+        \DashaMail\CurlStub::$response = json_encode(['code' => 0, 'data' => ['ok' => true]]);
+
+        $client = new Client('key');
+
+        $result = $client->listGet(['page' => 1]);
+
+        $this->assertSame(['ok' => true], $result);
+
+        $fields = [];
+        parse_str(\DashaMail\CurlStub::$options[CURLOPT_POSTFIELDS], $fields);
+
+        $this->assertSame('key', $fields['api_key']);
+        $this->assertSame('list.get', $fields['method']);
+        $this->assertSame('json', $fields['format']);
+        $this->assertSame('1', $fields['page']);
+    }
+
+    public function testCurlErrorThrowsException(): void
+    {
+        \DashaMail\CurlStub::$response = false;
+        \DashaMail\CurlStub::$error = 'timeout';
+
+        $client = new Client('key');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Curl error: timeout');
+
+        $client->listGet();
+    }
+
+    public function testInvalidJsonThrowsException(): void
+    {
+        \DashaMail\CurlStub::$response = '{invalid';
+
+        $client = new Client('key');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Ошибка декодирования JSON');
+
+        $client->listGet();
+    }
+
+    public function testApiErrorThrowsException(): void
+    {
+        \DashaMail\CurlStub::$response = json_encode(['code' => 123, 'message' => 'bad']);
+
+        $client = new Client('key');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('bad');
+
+        $client->listGet();
+    }
+}
+

--- a/tests/curl_stub.php
+++ b/tests/curl_stub.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace DashaMail;
+
+class CurlStub
+{
+    public static string $initUrl = '';
+    public static array $options = [];
+    public static string|false $response = '';
+    public static string $error = '';
+    public static int $httpCode = 200;
+    public static bool $closed = false;
+
+    public static function reset(): void
+    {
+        self::$initUrl = '';
+        self::$options = [];
+        self::$response = '';
+        self::$error = '';
+        self::$httpCode = 200;
+        self::$closed = false;
+    }
+}
+
+function curl_init(string $url)
+{
+    CurlStub::$initUrl = $url;
+    return 'curl';
+}
+
+function curl_setopt_array($ch, array $options): void
+{
+    CurlStub::$options = $options;
+}
+
+function curl_exec($ch)
+{
+    return CurlStub::$response;
+}
+
+function curl_error($ch): string
+{
+    return CurlStub::$error;
+}
+
+function curl_getinfo($ch, $opt)
+{
+    return CurlStub::$httpCode;
+}
+
+function curl_close($ch): void
+{
+    CurlStub::$closed = true;
+}
+


### PR DESCRIPTION
## Summary
- add PHPUnit unit tests for the DashaMail client
- stub cURL functions for test isolation

## Testing
- `./vendor/bin/phpunit --bootstrap vendor/autoload.php tests/ClientTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_683dd62b8cc0832cabd0de80f216ac38